### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can install Akira by compiling it from the source, here's the list of depend
  - `libxml-2.0`
  - `gtksourceview-3.0`
  
-**For non-elementary distros, (Arch, Debian etc) you are required "vala" as additional dependency.**
+**For non-elementary distros, (such as Arch, Debian etc) you are required to install "vala" as additional dependency.**
 
 ## Building
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ You can install Akira by compiling it from the source, here's the list of depend
  - `gobject-2.0`
  - `libxml-2.0`
  - `gtksourceview-3.0`
+ 
+**For non-elementary distros, (Arch, Debian etc) you are required "vala" as additional dependency.**
 
 ## Building
 ```


### PR DESCRIPTION
Non-elementary distros require "vala" too to compile it. 
Providing it directly on readme makes life easier for casual users and package maintainers :))