### PR TITLE
Reconfigure meson to fix config.vala.in

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,40 +16,6 @@ asresources = gnome.compile_resources(
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (meson.project_name()), language:'c')
 
 subdir('src')
-# Create a new executable, list the files we want to compile, list the dependencies we need, and install
-executable(
-    meson.project_name(),
-    'src/Main.vala',
-    'src/Application.vala',
-    'src/Window.vala',
-    'src/config.vala',
-    'src/Services/Settings.vala',
-    'src/Services/ActionManager.vala',
-    'src/Utils/Dialogs.vala',
-    'src/Layouts/HeaderBar.vala',
-    'src/Layouts/LeftSideBar.vala',
-    'src/Layouts/MainCanvas.vala',
-    'src/Layouts/MainWindow.vala',
-    'src/Layouts/RightSideBar.vala',
-    'src/Layouts/StatusBar.vala',
-    'src/Layouts/Partials/LayersPanel.vala',
-    'src/Layouts/Partials/PagesPanel.vala',
-    'src/Layouts/Partials/Artboard.vala',
-    'src/Layouts/Partials/Layer.vala',
-    'src/Partials/HeaderBarButton.vala',
-    'src/Partials/MenuButton.vala',
-    'src/Widgets/SettingsDialog.vala',
-    asresources,
-    dependencies: [
-        dependency('gtk+-3.0'),
-        dependency('granite'),
-        dependency('gee-0.8'),
-        dependency('libxml-2.0'),
-        dependency('gtksourceview-3.0'),
-    ],
-    install: true
-)
-
 meson.add_install_script('meson/post_install.py')
 subdir('data')
 subdir('po')

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,8 +6,42 @@ conf_data.set('RELEASE_NAME', 'Akira')
 conf_data.set('VERSION', '0.0.1')
 conf_data.set('VERSION_INFO', 'The Linux Design Tool')
 conf_data.set('PREFIX', get_option('prefix'))
-configure_file(
+config_header = configure_file(
     input: 'config.vala.in',
     output: 'config.vala',
     configuration: conf_data
+)
+
+# Create a new executable, list the files we want to compile, list the dependencies we need, and install
+executable(
+    meson.project_name(),
+    'Main.vala',
+    'Application.vala',
+    'Window.vala',
+    'Services/Settings.vala',
+    'Services/ActionManager.vala',
+    'Utils/Dialogs.vala',
+    'Layouts/HeaderBar.vala',
+    'Layouts/LeftSideBar.vala',
+    'Layouts/MainCanvas.vala',
+    'Layouts/MainWindow.vala',
+    'Layouts/RightSideBar.vala',
+    'Layouts/StatusBar.vala',
+    'Layouts/Partials/LayersPanel.vala',
+    'Layouts/Partials/PagesPanel.vala',
+    'Layouts/Partials/Artboard.vala',
+    'Layouts/Partials/Layer.vala',
+    'Partials/HeaderBarButton.vala',
+    'Partials/MenuButton.vala',
+    'Widgets/SettingsDialog.vala',
+    asresources,
+    config_header,
+    dependencies: [
+        dependency('gtk+-3.0'),
+        dependency('granite'),
+        dependency('gee-0.8'),
+        dependency('libxml-2.0'),
+        dependency('gtksourceview-3.0'),
+    ],
+    install: true
 )


### PR DESCRIPTION
I was getting the following when trying to build:

`meson.build:20:0: ERROR: File src/config.vala does not exist.`

I've tweaked your meson files slightly to properly define a `config_header` variable from the configured version of `config.vala.in` and include that in the build.

I also took the liberty to move your compilation stage into `src/meson.build` for neatness.