### PR TITLE
Avoid '__hidden' name collision

### DIFF
--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -54,9 +54,9 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 		get { return _locked; } set { _locked = value; }
 	}
 
-	private bool _hidden { get; set; default = false; }
+	private bool __hidden { get; set; default = false; }
 	public bool hidden {
-		get { return _hidden; } set { _hidden = value; }
+		get { return __hidden; } set { __hidden = value; }
 	}
 
 	// public Akira.Shape shape { get; construct; }


### PR DESCRIPTION
`/usr/include/sys/cdefs.h` on FreeBSD defines `__hidden` as `__attribute__((__visibility__("hidden")))`.
Vala expands `_hidden` into `__hidden`, so the macro gets expanded. Now `__hidden` will expand to `___hidden` and won't collide.