### PR TITLE
Add snapcraft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,65 @@
----
-
-language: node_js
-
-node_js:
-  - lts/*
-
-sudo: required
-
-services:
-  - docker
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - libstdc++-5-dev
-
-cache:
-  directories:
-    - /tmp/liftoff
-
 matrix:
   include:
-    - env: DIST=juno
+  - language: bash
 
-install:
-  - npm install @elementaryos/houston
+  dist: xenial
 
-script:
-  - houston ci
-    --distribution $DIST
+  env:
+    global:
+      - LC_ALL: C.UTF-8
+      - LANG: C.UTF-8
 
-branches:
-  only:
-  - master
+  addons:
+    snaps:
+      - name: snapcraft
+        channel: stable
+        classic: true
+      - name: http
+      - name: transfer
+
+  script:
+    - sudo apt update
+    - snapcraft --destructive-mode
+  after_success:
+    - cp *.snap "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
+    - timeout 180 /snap/bin/transfer "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
+  after_failure:
+    - sudo journalctl -u snapd
+    - http https://api.snapcraft.io/v2/snaps/info/core architecture==amd64 Snap-Device-Series:16
+
+  include:
+  - language: node_js
+
+  node_js:
+    - lts/*
+
+  sudo: required
+
+  services:
+    - docker
+
+  addons:
+    apt:
+      sources:
+        - ubuntu-toolchain-r-test
+      packages:
+        - libstdc++-5-dev
+
+  cache:
+    directories:
+      - /tmp/liftoff
+
+  matrix:
+    include:
+      - env: DIST=juno
+
+  install:
+    - npm install @elementaryos/houston
+
+  script:
+    - houston ci
+      --distribution $DIST
+
+  branches:
+    only:
+    - master

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,48 +47,8 @@ slots:
     name: com.github.alecaddd.akira
 
 parts:
-  granite:
-    plugin: cmake
-    source: https://github.com/elementary/granite/archive/5.2.2.tar.gz
-    source-type: tar
-    configflags: [-DCMAKE_BUILD_TYPE=Release, -DCMAKE_INSTALL_PREFIX=/usr, -DCMAKE_INSTALL_LIBDIR=/usr/lib]
-    build-packages:
-        - build-essential
-        - libgee-0.8-dev
-        - libgirepository1.0-dev
-        - libgtk-3-dev
-        - cmake
-        - gobject-introspection
-  desktop-gtk3:
-    build-packages:
-      - build-essential
-      - libgtk-3-dev
-    make-parameters:
-      - FLAVOR=gtk3
-    plugin: make
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-subdir: gtk
-    stage-packages:
-      - libxkbcommon0
-      - ttf-ubuntu-font-family
-      - dmz-cursor-theme
-      - light-themes
-      - adwaita-icon-theme
-      - gnome-themes-standard
-      - shared-mime-info
-      - libgtk-3-0
-      - libgdk-pixbuf2.0-0
-      - libglib2.0-bin
-      - libgtk-3-bin
-      - unity-gtk3-module
-      - libappindicator3-1
-      - locales-all
-      - xdg-user-dirs
-      - ibus-gtk3
-      - libibus-1.0-5
-      - fcitx-frontend-gtk3
   akira:
-    after: [desktop-gtk3, granite, desktop-gnome-platform]
+    after: [granite, desktop-gnome-platform]
     plugin: meson
     meson-parameters:
       - --prefix=/usr
@@ -107,41 +67,23 @@ parts:
       - libxml2-dev
       - libglib2.0-dev
     stage-packages:
-      - libatk1.0-0
-      - libatk-bridge2.0-0
-      - libatspi2.0-0
-      - libblkid1
-      - libbsd0
-      - libcairo2
-      - libcairo-gobject2
       - libdatrie1
       - libdbus-1-3
       - libepoxy0
       - libexpat1
       - libffi6
-      - libfontconfig1
-      - libfreetype6
       - libgcrypt20
       - libgee-0.8-2
-      - libgdk-pixbuf2.0-0
-      - libglib2.0-0
       - libgpg-error0
       - libgraphite2-3
-      - libgtk-3-0
       - libharfbuzz0b
       - liblz4-1
       - liblzma5
       - libmount1
-      - libpango-1.0-0
-      - libpangocairo-1.0-0
-      - libpangoft2-1.0-0
       - libpcre3
       - libpixman-1-0
       - libpng16-16
-      - libselinux1
-      - libsystemd0
       - libthai0
-      - libuuid1
       - libwayland-client0
       - libwayland-cursor0
       - libwayland-egl1-mesa
@@ -159,9 +101,20 @@ parts:
       - libxi6
       - libxinerama1
       - libxkbcommon0
-      - libxrandr2
       - libxrender1
       - zlib1g
+  granite:
+    plugin: cmake
+    source: https://github.com/elementary/granite/archive/5.2.2.tar.gz
+    source-type: tar
+    configflags: [-DCMAKE_BUILD_TYPE=Release, -DCMAKE_INSTALL_PREFIX=/usr, -DCMAKE_INSTALL_LIBDIR=/usr/lib]
+    build-packages:
+        - build-essential
+        - libgee-0.8-dev
+        - libgirepository1.0-dev
+        - libgtk-3-dev
+        - cmake
+        - gobject-introspection
   desktop-gnome-platform:
     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
     source-subdir: gtk

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,173 @@
+name: akira
+base: core18 
+version: git
+summary: Akira
+description: |
+  Native Linux App for UI and UX Design built in Vala and Gtk
+
+grade: stable
+confinement: strict
+icon: data/assets/icons/com.github.alecaddd.akira.png
+
+apps:
+  akira:
+    command: desktop-launch $SNAP/usr/bin/com.github.alecaddd.akira
+    plugs:
+      - desktop
+      - desktop-legacy
+      - opengl
+      - x11
+    slots: [ dbus-akira ]
+    desktop: usr/share/applications/com.github.alecaddd.akira.desktop
+    environment:
+      GSETTINGS_SCHEMA_DIR: $SNAP/share/glib-2.0/schemas
+
+plugs:
+  gnome-3-28-1804:
+    interface: content
+    target: $SNAP/gnome-platform
+    default-provider: gnome-3-28-1804
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes
+
+slots:
+  dbus-akira:
+    interface: dbus
+    bus: session
+    name: com.github.alecaddd.akira
+
+parts:
+  granite:
+    plugin: cmake
+    source: https://github.com/elementary/granite/archive/0.5.tar.gz
+    source-type: tar
+    configflags: [-DCMAKE_BUILD_TYPE=Release, -DCMAKE_INSTALL_PREFIX=/usr, -DCMAKE_INSTALL_LIBDIR=/usr/lib]
+    build-packages:
+        - build-essential
+        - libgee-0.8-dev
+        - libgirepository1.0-dev
+        - libgtk-3-dev
+        - cmake
+        - gobject-introspection
+  desktop-gtk3:
+    build-packages:
+      - build-essential
+      - libgtk-3-dev
+    make-parameters:
+      - FLAVOR=gtk3
+    plugin: make
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: gtk
+    stage-packages:
+      - libxkbcommon0
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - adwaita-icon-theme
+      - gnome-themes-standard
+      - shared-mime-info
+      - libgtk-3-0
+      - libgdk-pixbuf2.0-0
+      - libglib2.0-bin
+      - libgtk-3-bin
+      - unity-gtk3-module
+      - libappindicator3-1
+      - locales-all
+      - xdg-user-dirs
+      - ibus-gtk3
+      - libibus-1.0-5
+      - fcitx-frontend-gtk3
+  akira:
+    after: [desktop-gtk3, granite, desktop-gnome-platform]
+    plugin: meson
+    meson-parameters:
+      - --prefix=/usr
+    source: .
+    build-packages:
+      - libgtk-3-dev
+      - valac
+      - libgranite-dev
+      - libjson-glib-dev
+      - libgudev-1.0-dev
+      - libevdev-dev
+      - libgtksourceview-3.0-dev
+      - libxml2-dev
+      - libglib2.0-dev
+    stage-packages:
+      - libatk1.0-0
+      - libatk-bridge2.0-0
+      - libatspi2.0-0
+      - libblkid1
+      - libbsd0
+      - libc6
+      - libcairo2
+      - libcairo-gobject2
+      - libdatrie1
+      - libdbus-1-3
+      - libepoxy0
+      - libexpat1
+      - libffi6
+      - libfontconfig1
+      - libfreetype6
+      - libgcrypt20
+      - libgee-0.8-2
+      - libgdk-pixbuf2.0-0
+      - libglib2.0-0
+      - libgpg-error0
+      - libgraphite2-3
+      - libgtk-3-0
+      - libharfbuzz0b
+      - liblz4-1
+      - liblzma5
+      - libmount1
+      - libpango-1.0-0
+      - libpangocairo-1.0-0
+      - libpangoft2-1.0-0
+      - libpcre3
+      - libpixman-1-0
+      - libpng16-16
+      - libselinux1
+      - libsystemd0
+      - libthai0
+      - libuuid1
+      - libwayland-client0
+      - libwayland-cursor0
+      - libwayland-egl1-mesa
+      - libx11-6
+      - libxau6
+      - libxcb1
+      - libxcb-render0
+      - libxcb-shm0
+      - libxcomposite1
+      - libxcursor1
+      - libxdamage1
+      - libxdmcp6
+      - libxext6
+      - libxfixes3
+      - libxi6
+      - libxinerama1
+      - libxkbcommon0
+      - libxrandr2
+      - libxrender1
+      - zlib1g
+  desktop-gnome-platform:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: gtk
+    plugin: make
+    make-parameters: ["FLAVOR=gtk3"]
+    build-packages:
+      - build-essential
+      - libgtk-3-dev
+    override-build: |
+      snapcraftctl build
+      mkdir -pv $SNAPCRAFT_PART_INSTALL/gnome-platform

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ slots:
 parts:
   granite:
     plugin: cmake
-    source: https://github.com/elementary/granite/archive/0.5.tar.gz
+    source: https://github.com/elementary/granite/archive/5.2.2.tar.gz
     source-type: tar
     configflags: [-DCMAKE_BUILD_TYPE=Release, -DCMAKE_INSTALL_PREFIX=/usr, -DCMAKE_INSTALL_LIBDIR=/usr/lib]
     build-packages:
@@ -93,6 +93,9 @@ parts:
     meson-parameters:
       - --prefix=/usr
     source: .
+    override-build: |
+      snapcraftctl build
+      sed -i 's|Icon=com.github.alecaddd.akira|Icon=${SNAP}/data/assets/icons/com.github.alecaddd.akira.png|' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/com.github.alecaddd.akira.desktop
     build-packages:
       - libgtk-3-dev
       - valac
@@ -109,7 +112,6 @@ parts:
       - libatspi2.0-0
       - libblkid1
       - libbsd0
-      - libc6
       - libcairo2
       - libcairo-gobject2
       - libdatrie1


### PR DESCRIPTION
Hello!

This pull request adds the capability to build a snap of Akira. I realise you're super busy with your crowdfunding campaign, and packaging isn't your top priority, so no worries if you don't have time to review and/or merge it right now! :D 

I have tested this on Ubuntu 18.04 and KDE Neon. It builds using `snapcraft` and `multipass`. Here's how I build it.

```
snap install snapcraft --classic
snap install multipass --beta --classic
git clone https://github.com/popey/Akira
git checkout "add-snapcraft"
cd Akira
snapcraft
```

This should build a snap around 6.6MB in size. It leverages the `gnome-3-28-1804` content snap to save some space, and reduce duplication. 

Any questions, happy to answer them here. Good luck with the campaign!